### PR TITLE
feat: adiciona models e migrations para o fluxo de doação

### DIFF
--- a/Laravel/app/Models/Batch.php
+++ b/Laravel/app/Models/Batch.php
@@ -3,8 +3,33 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Batch extends Model
 {
-    //
+    // Permite que essas colunas sejam salvas em massa
+    protected $fillable = [
+        'product_id', 
+        'batch_number', 
+        'quantity', 
+        'entry_date', 
+        'expiration_date'
+    ];
+
+    protected $casts = [
+    'entry_date' => 'date',
+    'expiration_date' => 'date',
+    ];
+
+    // Cria o relacionamento com o Produto
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function donations(): HasMany
+    {
+    return $this->hasMany(Donation::class);
+    }
 }

--- a/Laravel/app/Models/Donation.php
+++ b/Laravel/app/Models/Donation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Donation extends Model
+{
+    protected $fillable = [
+        'store_id',
+        'batch_id',
+        'quantity',
+        'status',
+    ];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'store_id');
+    }
+
+    public function batch(): BelongsTo
+    {
+        return $this->belongsTo(Batch::class);
+    }
+
+    public function requests(): HasMany
+    {
+        return $this->hasMany(DonationRequest::class);
+    }
+}

--- a/Laravel/app/Models/DonationRequest.php
+++ b/Laravel/app/Models/DonationRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DonationRequest extends Model
+{
+    protected $fillable = [
+        'donation_id',
+        'donatario_id',
+        'status',
+    ];
+
+    public function donation(): BelongsTo
+    {
+        return $this->belongsTo(Donation::class);
+    }
+
+    public function donatario(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'donatario_id');
+    }
+}

--- a/Laravel/app/Models/User.php
+++ b/Laravel/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -45,5 +46,25 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
+    }
+
+    /**
+     * Doações criadas pelo mercado.
+     */
+    public function donations(): HasMany
+    {
+        return $this->hasMany(Donation::class, 'store_id');
+    }
+
+    /**
+     * Solicitações de doação feitas pelo donatário.
+     */
+    public function donationRequests(): HasMany
+    {
+        return $this->hasMany(DonationRequest::class, 'donatario_id');
     }
 }

--- a/Laravel/database/migrations/2026_05_01_232403_create_donations_table.php
+++ b/Laravel/database/migrations/2026_05_01_232403_create_donations_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('donations', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('store_id')
+                ->constrained('users')
+                ->onDelete('cascade');
+
+            $table->foreignId('batch_id')
+                ->constrained('batches')
+                ->onDelete('cascade');
+
+            $table->integer('quantity');
+
+            $table->enum('status', [
+                'disponivel',
+                'em_processo',
+                'finalizada'
+            ])->default('disponivel');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('donations');
+    }
+};

--- a/Laravel/database/migrations/2026_05_01_232530_create_donation_requests_table.php
+++ b/Laravel/database/migrations/2026_05_01_232530_create_donation_requests_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('donation_requests', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('donation_id')
+                ->constrained()
+                ->onDelete('cascade');
+
+            $table->foreignId('donatario_id')
+                ->constrained('users')
+                ->onDelete('cascade');
+
+            $table->enum('status', [
+                'pendente',
+                'aceito',
+                'recusado',
+                'concluido'
+            ])->default('pendente');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('donation_requests');
+    }
+};


### PR DESCRIPTION
Closes #38 

feat: cria models e migrations base para o fluxo de doações

- Implementa model e migration `Donation` com chaves estrangeiras para `store_id` e `batch_id`.
- Implementa model e migration `DonationRequest` vinculando doações a donatários.
- Define os status padrão para ofertas e pedidos.
- Estabelece os relacionamentos (hasMany/belongsTo) para suportar a separação entre a "Oferta" (prateleira) e o "Pedido" (fila de interessados).