### PR TITLE
fix: migrations para campos nullable em products e status em batches

### DIFF
--- a/Laravel/database/migrations/2026_05_04_223043_make_quantity_nullable_in_products_table.php
+++ b/Laravel/database/migrations/2026_05_04_223043_make_quantity_nullable_in_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('quantity')->nullable()->default(0)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->integer('quantity')->nullable(false)->change();
+        });
+    }
+};

--- a/Laravel/database/migrations/2026_05_04_223509_make_expiration_date_nullable_in_products_table.php
+++ b/Laravel/database/migrations/2026_05_04_223509_make_expiration_date_nullable_in_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->date('expiration_date')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->date('expiration_date')->nullable(false)->change();
+        });
+    }
+};

--- a/Laravel/database/migrations/2026_05_04_223858_add_status_to_batches_table.php
+++ b/Laravel/database/migrations/2026_05_04_223858_add_status_to_batches_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('batches', function (Blueprint $table) {
+            $table->string('status')->default('disponivel')->after('entry_date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('batches', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};


### PR DESCRIPTION
## O que foi corrigido
- Campo `quantity` da tabela `products` tornado nullable com default 0
- Campo `expiration_date` da tabela `products` tornado nullable
- Campo `status` adicionado na tabela `batches` com default 'disponivel'

## Por que foi necessário
O time removeu `quantity` e `expiration_date` do `$fillable` do Model Product
pois a lógica foi migrada para os lotes (batches). Porém a tabela ainda
exigia esses campos, causando erro 500 ao cadastrar produtos.
O campo `status` estava no `$fillable` do Batch mas não existia na tabela.

## Testado
- ✅ Cadastro de produto funcionando sem erros
- ✅ Lote criado corretamente após o produto
- ✅ Tela de produtos exibindo os cards corretamente