### PR TITLE
feat: integrar controller com o front em solicitação de doações

### DIFF
--- a/Laravel/app/Http/Controllers/DonationController.php
+++ b/Laravel/app/Http/Controllers/DonationController.php
@@ -55,13 +55,22 @@ class DonationController extends Controller
 
     public function index()
 {
-    // Pega todas as doações da loja logada e traz os dados do lote/produto junto
-        $donations = \App\Models\Donation::with('batch.product')
-            ->where('store_id', \Illuminate\Support\Facades\Auth::id())
-            ->get();
+    // Pega todas as doações da loja logada
+    $donations = \App\Models\Donation::with(['batch.product', 'requests'])
+        ->where('store_id', Auth::id())
+        ->get();
 
-        return view('manager.doacoes', compact('donations'));
-    }
+    // Pega todas as solicitações recebidas para as doações deste gerente
+    $donationRequests = \App\Models\DonationRequest::whereHas('donation', function ($q) {
+            $q->where('store_id', Auth::id());
+        })
+        ->with(['donation.batch.product', 'donatario'])
+        ->whereIn('status', ['pendente', 'aceito'])
+        ->orderByRaw("FIELD(status, 'pendente', 'aceito')")
+        ->get();
+
+    return view('manager.doacoes', compact('donations', 'donationRequests'));
+}
 
     /**
      * Aprovar ou recusar uma solicitação de doação (apenas manager)

--- a/Laravel/routes/web.php
+++ b/Laravel/routes/web.php
@@ -48,21 +48,7 @@ Route::get('manager/produtos', [ProductController::class, 'index'])->name('manag
 Route::post('/manager/produtos', [ProductController::class, 'store'])->name('manager.produtos.store');
 
 // Rota de Doações do Manager - Integrada com os Models[cite: 2, 7]
-Route::get('/manager/doacoes', function () {
-    // Busca doações do gerente logado com as relações de lote e produto[cite: 7]
-    $donations = \App\Models\Donation::where('store_id', Auth::id())
-        ->with(['batch.product'])
-        ->get();
-
-    // Busca solicitações pendentes para as doações deste gerente[cite: 1, 2]
-    $donationRequests = \App\Models\DonationRequest::whereHas('donation', function($q) {
-            $q->where('store_id', Auth::id());
-        })
-        ->with(['donation.batch.product'])
-        ->get();
-
-    return view('manager.doacoes', compact('donations', 'donationRequests'));
-})->name('manager.doacoes');
+Route::get('/manager/doacoes', [DonationController::class, 'index'])->name('manager.doacoes');
 
 // --- VIEWS DO USER (DONATÁRIO) ---
 


### PR DESCRIPTION
## O que foi feito
- Atualizado método `index()` no DonationController para passar
  `$donations` e `$donationRequests` para a view
- Solicitações ordenadas por prioridade: pendentes primeiro, depois aceitas
- Rota `/manager/doacoes` apontada para `DonationController@index`
  em vez de closure anônima

## Fluxo testado
- ✅ Tela de doações exibe produtos disponíveis para doação
- ✅ Solicitações pendentes aparecem com botões Aceitar/Recusar
- ✅ Aceitar solicitação muda status e exibe "Marcar como retirado"
- ✅ Recusar solicitação funciona corretamente
- ✅ Concluir doação atualiza estoque e limpa a lista
- ✅ Contador de solicitações atualiza em tempo real